### PR TITLE
Add variable board size

### DIFF
--- a/TicTacToe.Tests/BoardTests.cs
+++ b/TicTacToe.Tests/BoardTests.cs
@@ -1,0 +1,26 @@
+using System;
+using Xunit;
+
+namespace TicTacToe.Tests
+{
+    public class BoardTests
+    {
+        [Fact]
+        public void CreateNew3x3Board()
+        {
+            BoardFactory boardFactory = new BoardFactory();
+            Board newBoard = boardFactory.BuildBoard(3);
+
+            Assert.Equal(9, newBoard.Length());
+        }
+
+        [Fact]
+        public void CreateNew5x5Board()
+        {
+            BoardFactory boardFactory = new BoardFactory();
+            Board newBoard = boardFactory.BuildBoard(5);
+
+            Assert.Equal(25, newBoard.Length());
+        }
+    }
+}

--- a/TicTacToe.Tests/BoardTests.cs
+++ b/TicTacToe.Tests/BoardTests.cs
@@ -31,8 +31,8 @@ namespace TicTacToe.Tests
             Board new3x3Board = boardFactory.BuildBoard(3);
             Board new5x5Board = boardFactory.BuildBoard(5);
 
-            Assert.Equal("3", new3x3Board.gameBoard[ 0, 2 ]);
-            Assert.Equal("25", new5x5Board.gameBoard[ 4, 4 ]);
+            Assert.Equal("3", new3x3Board.gameBoard[ 2 ]);
+            Assert.Equal("25", new5x5Board.gameBoard[ 24 ]);
         }
     }
 }

--- a/TicTacToe.Tests/BoardTests.cs
+++ b/TicTacToe.Tests/BoardTests.cs
@@ -43,5 +43,29 @@ namespace TicTacToe.Tests
             Assert.True(newBoard.SpaceIsAvailable(2));
             Assert.False(newBoard.SpaceIsAvailable(3));
         }
+
+        [Fact]
+        public void CanGetSpecificRow()
+        {
+            Board new3x3Board = boardFactory.BuildBoard(3);
+            Board new4x4Board = boardFactory.BuildBoard(4);
+            string[] middleRow3x3 = new string[] { "4", "5", "6" };
+            string[] lastRow4x4 = new string[] { "13", "14", "15", "16" };
+
+            Assert.Equal(middleRow3x3, new3x3Board.GetRow(2));
+            Assert.Equal(lastRow4x4, new4x4Board.GetRow(4));
+        }
+
+        [Fact]
+        public void CanGetSpecificColumn()
+        {
+            Board new3x3Board = boardFactory.BuildBoard(3);
+            Board new4x4Board = boardFactory.BuildBoard(4);
+            string[] middleCol3x3 = new string[] { "2", "5", "8" };
+            string[] lastCol4x4 = new string[] { "4", "8", "12", "16" };
+
+            Assert.Equal(middleCol3x3, new3x3Board.GetColumn(2));
+            Assert.Equal(lastCol4x4, new4x4Board.GetColumn(4));
+        }
     }
 }

--- a/TicTacToe.Tests/BoardTests.cs
+++ b/TicTacToe.Tests/BoardTests.cs
@@ -91,5 +91,22 @@ namespace TicTacToe.Tests
             Assert.Equal(up3x3, new3x3Board.GetUpDiagonal());
             Assert.Equal(up4x4, new4x4Board.GetUpDiagonal());
         }
+
+        [Fact]
+        public void CanGenerateRandomNumber()
+        {
+            var computer = new HardComputerPlayer();
+            Game game = new Game();
+            game.Board = boardFactory.BuildBoard(4);
+
+            int space = game.Board.GetRandomSpace();
+            Assert.InRange(space, 1, 16);
+            space = game.Board.GetRandomSpace();
+            Assert.InRange(space, 1, 16);
+            space = game.Board.GetRandomSpace();
+            Assert.InRange(space, 1, 16);
+            space = game.Board.GetRandomSpace();
+            Assert.InRange(space, 1, 16);
+        }
     }
 }

--- a/TicTacToe.Tests/BoardTests.cs
+++ b/TicTacToe.Tests/BoardTests.cs
@@ -34,5 +34,14 @@ namespace TicTacToe.Tests
             Assert.Equal("3", new3x3Board.gameBoard[ 2 ]);
             Assert.Equal("25", new5x5Board.gameBoard[ 24 ]);
         }
+
+        [Fact]
+        public void CheckSpaceAvailability()
+        {
+            Board newBoard = boardFactory.BuildBoard(3);
+            newBoard.gameBoard = new string[] { "X", "2", "O", "O", "5", "6", "X", "8", "9" };
+            Assert.True(newBoard.SpaceIsAvailable(2));
+            Assert.False(newBoard.SpaceIsAvailable(3));
+        }
     }
 }

--- a/TicTacToe.Tests/BoardTests.cs
+++ b/TicTacToe.Tests/BoardTests.cs
@@ -5,10 +5,12 @@ namespace TicTacToe.Tests
 {
     public class BoardTests
     {
+        BoardFactory boardFactory = new BoardFactory();
+
         [Fact]
         public void CreateNew3x3Board()
         {
-            BoardFactory boardFactory = new BoardFactory();
+            // BoardFactory boardFactory = new BoardFactory();
             Board newBoard = boardFactory.BuildBoard(3);
 
             Assert.Equal(9, newBoard.Length());
@@ -17,10 +19,20 @@ namespace TicTacToe.Tests
         [Fact]
         public void CreateNew5x5Board()
         {
-            BoardFactory boardFactory = new BoardFactory();
+            // BoardFactory boardFactory = new BoardFactory();
             Board newBoard = boardFactory.BuildBoard(5);
 
             Assert.Equal(25, newBoard.Length());
+        }
+
+        [Fact]
+        public void FillInSpaces()
+        {
+            Board new3x3Board = boardFactory.BuildBoard(3);
+            Board new5x5Board = boardFactory.BuildBoard(5);
+
+            Assert.Equal("3", new3x3Board.gameBoard[ 0, 2 ]);
+            Assert.Equal("25", new5x5Board.gameBoard[ 4, 4 ]);
         }
     }
 }

--- a/TicTacToe.Tests/BoardTests.cs
+++ b/TicTacToe.Tests/BoardTests.cs
@@ -67,5 +67,29 @@ namespace TicTacToe.Tests
             Assert.Equal(middleCol3x3, new3x3Board.GetColumn(2));
             Assert.Equal(lastCol4x4, new4x4Board.GetColumn(4));
         }
+
+        [Fact]
+        public void CanGetDownDiagonal()
+        {
+            Board new3x3Board = boardFactory.BuildBoard(3);
+            Board new4x4Board = boardFactory.BuildBoard(4);
+            string[] down3x3 = new string[] { "1", "5", "9" };
+            string[] down4x4 = new string[] { "1", "6", "11", "16" };
+
+            Assert.Equal(down3x3, new3x3Board.GetDownDiagonal());
+            Assert.Equal(down4x4, new4x4Board.GetDownDiagonal());
+        }
+
+        [Fact]
+        public void CanGetUpDiagonal()
+        {
+            Board new3x3Board = boardFactory.BuildBoard(3);
+            Board new4x4Board = boardFactory.BuildBoard(4);
+            string[] up3x3 = new string[] { "7", "5", "3" };
+            string[] up4x4 = new string[] { "13", "10", "7", "4" };
+
+            Assert.Equal(up3x3, new3x3Board.GetUpDiagonal());
+            Assert.Equal(up4x4, new4x4Board.GetUpDiagonal());
+        }
     }
 }

--- a/TicTacToe.Tests/CLITests.cs
+++ b/TicTacToe.Tests/CLITests.cs
@@ -26,7 +26,8 @@ namespace TicTacToe.Tests
         [InlineData("       |       |   O ")]
         public void TestPrintCurrentBoard(string line)
         {
-            string[] board = { " ", "X", " ", " ", " ", "O",  "X", " ", " " };
+            Board board = new Board(3);
+            board.gameBoard = new string[] { " ", "X", " ", " ", " ", "O",  "X", " ", " " };
             var currentConsoleOut = Console.Out;
             using (var consoleOutput = new ConsoleOutput())
             {

--- a/TicTacToe.Tests/CLITests.cs
+++ b/TicTacToe.Tests/CLITests.cs
@@ -26,7 +26,7 @@ namespace TicTacToe.Tests
         [InlineData("       |       |   O ")]
         public void TestPrintCurrentBoard(string line)
         {
-            char[] board = { ' ', 'X', ' ', ' ', ' ', 'O',  'X', ' ', ' ' };
+            string[] board = { " ", "X", " ", " ", " ", "O",  "X", " ", " " };
             var currentConsoleOut = Console.Out;
             using (var consoleOutput = new ConsoleOutput())
             {

--- a/TicTacToe.Tests/CLITestsHelper.cs
+++ b/TicTacToe.Tests/CLITestsHelper.cs
@@ -36,10 +36,12 @@ namespace TicTacToe.Tests
             return fakeNames;
         }
 
-        public int GetPlayerMove(Player player) => 4;
+        public int GetPlayerMove(Player player, int boardSize) => 4;
 
         public int GetNumberOfPlayers() => 1;
 
         public int GetDifficultyLevel() => 2;
+
+        public int GetBoardSize() => 3;
     }
 }

--- a/TicTacToe.Tests/ComputerPlayerTests.cs
+++ b/TicTacToe.Tests/ComputerPlayerTests.cs
@@ -24,23 +24,5 @@ namespace TicTacToe.Tests
             move = computer.FindBestMove(game);
             Assert.Equal(-1, move);         
         }
-
-        [Fact]
-        public void CanGenerateRandomNumberBetween1and9()
-        {
-            var computer = new HardComputerPlayer();
-            Game game = new Game();
-            game.Board = new Board(3);
-            game.Board.gameBoard = new string[] { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
-
-            int space = computer.PickRandomSpace(game);
-            Assert.InRange(space, 1, 9);
-            space = computer.PickRandomSpace(game);
-            Assert.InRange(space, 1, 9);
-            space = computer.PickRandomSpace(game);
-            Assert.InRange(space, 1, 9);
-            space = computer.PickRandomSpace(game);
-            Assert.InRange(space, 1, 9);
-        }
     }
 }

--- a/TicTacToe.Tests/ComputerPlayerTests.cs
+++ b/TicTacToe.Tests/ComputerPlayerTests.cs
@@ -9,16 +9,18 @@ namespace TicTacToe.Tests
         public void CanDetermineBestMoveOnBoard()
         {
             var computer = new HardComputerPlayer();
+            Board newBoard = new Board(3);
             Game game = new Game();
+            game.Board = newBoard;
 
             // Finds a move that would result in a win for either player
-            game.Board = new char[] { '1', 'X', 'X', 'O', '5', '6', 'O', '8', '9' };
+            game.Board.gameBoard = new string[] { "1", "X", "X", "O", "5", "6", "O", "8", "9" };
 
             int move = computer.FindBestMove(game);
             Assert.Equal(1, move);
 
             // Returns -1 if no move would result in a win for either player
-            game.Board = new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+            game.Board.gameBoard = new string[] { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
             move = computer.FindBestMove(game);
             Assert.Equal(-1, move);         
         }
@@ -27,8 +29,9 @@ namespace TicTacToe.Tests
         public void CanGenerateRandomNumberBetween1and9()
         {
             var computer = new HardComputerPlayer();
-            Game game = new Game ();
-            game.Board = new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+            Game game = new Game();
+            game.Board = new Board(3);
+            game.Board.gameBoard = new string[] { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
 
             int space = computer.PickRandomSpace(game);
             Assert.InRange(space, 1, 9);

--- a/TicTacToe.Tests/GameTests.cs
+++ b/TicTacToe.Tests/GameTests.cs
@@ -14,10 +14,10 @@ namespace TicTacToe.Tests
         public void CanCreateNewGame() => Assert.IsType<Game>(game);
 
         [Fact]
-        public void GameHasABoard() => Assert.IsType<Char[]>(game.Board);
+        public void GameHasABoard() => Assert.IsType<Board>(game.Board);
 
-        [Fact]
-        public void GameBoardHasNineSpaces() => Assert.Equal(9, game.Board.Length);
+        // [Fact]
+        // public void GameBoardHasNineSpaces() => Assert.Equal(9, game.Board.Length);
 
         [Fact]
         public void GameHasTwoPlayers()
@@ -33,13 +33,14 @@ namespace TicTacToe.Tests
         [Fact]
         public void GameCanMakeMoveOnBoard()
         {
+            game.Board = new Board(3);
         //Given a player has joined a game
             game.Player1 = player1;
             game.CurrentPlayer = player1;
         //When player picks a valid space
             game.MakeMove(2);
         //Then Board is updated with player's marker
-            Assert.Equal(game.Player1Marker, game.Board[1]);
+            Assert.Equal(game.Player1Marker, game.Board.gameBoard[1]);
         }
 
         [Fact]
@@ -56,13 +57,13 @@ namespace TicTacToe.Tests
             Assert.Equal(4, move);
         }
 
-        [Fact]
-        public void GameCanCheckMoveAvailability()
-        {
-            game.Board = new char[] { 'X', '2', 'O', 'O', '5', '6', 'X', '8', '9' };
-            Assert.True(game.SpaceIsAvailable(2));
-            Assert.False(game.SpaceIsAvailable(3));
-        }
+        // [Fact]
+        // public void GameCanCheckMoveAvailability()
+        // {
+        //     game.Board = new string[] { 'X', '2', 'O', 'O', '5', '6', 'X', '8', '9' };
+        //     Assert.True(game.SpaceIsAvailable(2));
+        //     Assert.False(game.SpaceIsAvailable(3));
+        // }
 
         [Fact]
         public void GameCanAlternatePlayers()
@@ -81,17 +82,20 @@ namespace TicTacToe.Tests
         [Fact]
         public void GameCanDetermineIfOver()
         {
-            char[] winnerBoard = { 'X', 'X', 'X', 'O', '5', '6', 'O', '8', '9' };   // X has three on top row
-            char[] drawBoard = { 'X', 'X', 'O', 'O', 'O', 'X', 'X', 'O', 'X' };     // full board with no winner
-            char[] inPlayBoard = { 'X', '2', 'O', 'O', '5', '6', 'X', '8', '9' };   // board not yet full, no winner yet
+            Board newBoard = new Board(3);
+            game.Board = newBoard;
+            
+            string[] winnerBoard = { "X", "X", "X", "O", "5", "6", "O", "8", "9" };   // X has three on top row
+            string[] drawBoard = { "X", "X", "O", "O", "O", "X", "X", "O", "X" };     // full board with no winner
+            string[] inPlayBoard = { "X", "2", "O", "O", "5", "6", "X", "8", "9" };   // board not yet full, no winner yet
 
-            game.Board = winnerBoard;
+            game.Board.gameBoard = winnerBoard;
             Assert.True(game.IsOver());
 
-            game.Board = drawBoard;
+            game.Board.gameBoard = drawBoard;
             Assert.True(game.IsOver());
 
-            game.Board = inPlayBoard;
+            game.Board.gameBoard = inPlayBoard;
             Assert.False(game.IsOver());
         }
 

--- a/TicTacToe.Tests/GameTests.cs
+++ b/TicTacToe.Tests/GameTests.cs
@@ -85,11 +85,19 @@ namespace TicTacToe.Tests
             Board newBoard = new Board(3);
             game.Board = newBoard;
             
-            string[] winnerBoard = { "X", "X", "X", "O", "5", "6", "O", "8", "9" };   // X has three on top row
+            string[] rowWinnerBoard = { "X", "X", "X", "O", "5", "6", "O", "8", "9" };   // X has three on top row
+            string[] colWinnerBoard = { "O", "2", "X", "O", "X", "6", "O", "8", "9" };
+            string[] diagonalWinnerBoard = { "X", "2", "O", "O", "X", "6", "O", "8", "X" };
             string[] drawBoard = { "X", "X", "O", "O", "O", "X", "X", "O", "X" };     // full board with no winner
             string[] inPlayBoard = { "X", "2", "O", "O", "5", "6", "X", "8", "9" };   // board not yet full, no winner yet
 
-            game.Board.gameBoard = winnerBoard;
+            game.Board.gameBoard = rowWinnerBoard;
+            Assert.True(game.IsOver());
+
+            game.Board.gameBoard = colWinnerBoard;
+            Assert.True(game.IsOver());
+
+            game.Board.gameBoard = diagonalWinnerBoard;
             Assert.True(game.IsOver());
 
             game.Board.gameBoard = drawBoard;

--- a/TicTacToe.Tests/PlayerTests.cs
+++ b/TicTacToe.Tests/PlayerTests.cs
@@ -7,7 +7,7 @@ namespace TicTacToe.Tests
     public class PlayerTests
     {
         static string name = "Matt";
-        static char marker = 'X';
+        static string marker = "X";
         Player player = new Player(name, marker);
 
         [Fact]

--- a/TicTacToe/Board.cs
+++ b/TicTacToe/Board.cs
@@ -6,10 +6,10 @@ namespace TicTacToe
     {
         public Board(int side)
         {
-            this.gameBoard = new string[ side, side ];
+            this.gameBoard = new string[ side * side ];
             this.side = side;
         }
-        public string[,] gameBoard { get; set; }
+        public string[] gameBoard { get; set; }
         public int side { get; }
 
         public int Length() => this.gameBoard.Length;

--- a/TicTacToe/Board.cs
+++ b/TicTacToe/Board.cs
@@ -6,9 +6,11 @@ namespace TicTacToe
     {
         public Board(int side)
         {
-            this.gameBoard = new char[ side, side ];
+            this.gameBoard = new string[ side, side ];
+            this.side = side;
         }
-        public char[,] gameBoard { get; set; }
+        public string[,] gameBoard { get; set; }
+        public int side { get; }
 
         public int Length() => this.gameBoard.Length;
     }

--- a/TicTacToe/Board.cs
+++ b/TicTacToe/Board.cs
@@ -64,6 +64,21 @@ namespace TicTacToe
             return gameBoard[index] == space.ToString();
         }
 
+        public int GetRandomSpace()
+        {
+            Random rand = new Random();
+            int moveMax = side * side;
+            int randomSpace = rand.Next(1, moveMax);
+            if (SpaceIsAvailable(randomSpace))
+            {
+                return randomSpace;
+            }
+            else
+            {
+                return GetRandomSpace();
+            }
+        }
+
         public bool IsFull()
         {
             for ( int i = 1; i < gameBoard.Length + 1; i++ )

--- a/TicTacToe/Board.cs
+++ b/TicTacToe/Board.cs
@@ -14,6 +14,28 @@ namespace TicTacToe
 
         public int Length() => this.gameBoard.Length;
 
+        public string[] GetRow(int rowNumber)
+        {
+            string[] rowArray = new string[side];
+            int startingIndex = (rowNumber - 1) * side;
+            for (int i = 0; i < side; i++)
+            {
+                rowArray[i] = gameBoard[startingIndex + i];
+            }
+            return rowArray;
+        }
+
+        public string[] GetColumn(int colNumber)
+        {
+            string[] ColArray = new string[side];
+            int startingIndex = (colNumber - 1);
+            for (int i = 0; i < side; i++)
+            {
+                ColArray[i] = gameBoard[startingIndex + i * side];
+            }
+            return ColArray;
+        }
+
         public bool SpaceIsAvailable(int space)
         {
             int index = space - 1;
@@ -37,5 +59,18 @@ namespace TicTacToe
             int index = space - 1;
             gameBoard[index] = marker;
         }
+
+        // public bool HasWinningCombination()
+        // {
+        //     bool[] rowArray = new bool[3];
+        //     bool[] colArray = new bool[3];
+        //     for (int row = 0; row < Length(); row += side)
+        //     {
+        //         for (int col = 0; col < side - 1; col++)
+        //         {
+        //             rowArray[]
+        //         }
+        //     }
+        // }
     }
 }

--- a/TicTacToe/Board.cs
+++ b/TicTacToe/Board.cs
@@ -13,5 +13,29 @@ namespace TicTacToe
         public int side { get; }
 
         public int Length() => this.gameBoard.Length;
+
+        public bool SpaceIsAvailable(int space)
+        {
+            int index = space - 1;
+            return gameBoard[index] == space.ToString();
+        }
+
+        public bool IsFull()
+        {
+            for ( int i = 1; i < gameBoard.Length + 1; i++ )
+            {
+                if (SpaceIsAvailable(i))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public void UpdateSpace(int space, string marker)
+        {
+            int index = space - 1;
+            gameBoard[index] = marker;
+        }
     }
 }

--- a/TicTacToe/Board.cs
+++ b/TicTacToe/Board.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace TicTacToe
 {
@@ -81,17 +82,23 @@ namespace TicTacToe
             gameBoard[index] = marker;
         }
 
-        // public bool HasWinningCombination()
-        // {
-        //     bool[] rowArray = new bool[3];
-        //     bool[] colArray = new bool[3];
-        //     for (int row = 0; row < Length(); row += side)
-        //     {
-        //         for (int col = 0; col < side - 1; col++)
-        //         {
-        //             rowArray[]
-        //         }
-        //     }
-        // }
+        public bool HasWinningCombination()
+        {
+            for (int i = 1; i <= side; i++)
+            {
+                string[] sortedRow = GetRow(i).OrderBy(s => s).ToArray();
+                string[] sortedColumn = GetColumn(i).OrderBy(s => s).ToArray();
+                bool rowWin = sortedRow[0] == sortedRow[side - 1];
+                bool columnWin = sortedColumn[0] == sortedColumn[side - 1];
+                if ( rowWin || columnWin )
+                {
+                    return true;
+                }
+            }
+            string[] sortedDownDiagonal = GetDownDiagonal().OrderBy(s => s).ToArray();
+            string[] sortedUpDiagonal = GetUpDiagonal().OrderBy(s => s).ToArray();
+            bool diagonalWin = sortedDownDiagonal[0] == sortedDownDiagonal[side - 1] || sortedUpDiagonal[0] == sortedUpDiagonal[side - 1];
+            return diagonalWin ? true : false;
+        }
     }
 }

--- a/TicTacToe/Board.cs
+++ b/TicTacToe/Board.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace TicTacToe
+{
+    public class Board
+    {
+        public Board(int side)
+        {
+            this.gameBoard = new char[ side, side ];
+        }
+        public char[,] gameBoard { get; set; }
+
+        public int Length() => this.gameBoard.Length;
+    }
+}

--- a/TicTacToe/Board.cs
+++ b/TicTacToe/Board.cs
@@ -36,6 +36,27 @@ namespace TicTacToe
             return ColArray;
         }
 
+        public string[] GetDownDiagonal()
+        {
+            string[] diagonalArray = new string[side];
+            for (int i = 0; i < side; i++)
+            {
+                diagonalArray[i] = gameBoard[(side + 1) * i];
+            }
+            return diagonalArray;
+        }
+
+        public string[] GetUpDiagonal()
+        {
+            string[] diagonalArray = new string[side];
+            int startingIndex = side * (side - 1);
+            for (int i = 0; i < side; i++)
+            {
+                diagonalArray[i] = gameBoard[startingIndex - (i * (side - 1))];
+            }
+            return diagonalArray;
+        }
+
         public bool SpaceIsAvailable(int space)
         {
             int index = space - 1;

--- a/TicTacToe/BoardFactory.cs
+++ b/TicTacToe/BoardFactory.cs
@@ -12,14 +12,9 @@ namespace TicTacToe
 
         public Board PopulateBoard(Board board)
         {
-            int space = 1;
-            for (int row = 0; row < board.side; row++)
+            for (int space = 1; space <= board.gameBoard.Length; space++)
             {
-                for (int col = 0; col < board.side; col++)
-                {
-                    board.gameBoard[ row, col ] = space.ToString();
-                    space++;
-                }
+                board.gameBoard[space - 1] = space.ToString();
             }
             return board;
         }

--- a/TicTacToe/BoardFactory.cs
+++ b/TicTacToe/BoardFactory.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TicTacToe
+{
+    public class BoardFactory
+    {
+        public Board BuildBoard(int size)
+        {
+            Board newBoard = new Board(size);
+            return newBoard;
+        }
+    }
+}

--- a/TicTacToe/BoardFactory.cs
+++ b/TicTacToe/BoardFactory.cs
@@ -7,7 +7,21 @@ namespace TicTacToe
         public Board BuildBoard(int size)
         {
             Board newBoard = new Board(size);
-            return newBoard;
+            return PopulateBoard(newBoard);
+        }
+
+        public Board PopulateBoard(Board board)
+        {
+            int space = 1;
+            for (int row = 0; row < board.side; row++)
+            {
+                for (int col = 0; col < board.side; col++)
+                {
+                    board.gameBoard[ row, col ] = space.ToString();
+                    space++;
+                }
+            }
+            return board;
         }
     }
 }

--- a/TicTacToe/BoardFactory.cs
+++ b/TicTacToe/BoardFactory.cs
@@ -12,7 +12,7 @@ namespace TicTacToe
 
         public Board PopulateBoard(Board board)
         {
-            for (int space = 1; space <= board.gameBoard.Length; space++)
+            for (int space = 1; space <= board.Length(); space++)
             {
                 board.gameBoard[space - 1] = space.ToString();
             }

--- a/TicTacToe/CLI.cs
+++ b/TicTacToe/CLI.cs
@@ -32,13 +32,14 @@ namespace TicTacToe
             return names;
         }
 
-        public int GetPlayerMove(Player player)
+        public int GetPlayerMove(Player player, int boardSize)
         {
+            int moveMax = boardSize * boardSize;
             Console.WriteLine($"{player.Name}, please select a space on the board");
             string playerInput = Console.ReadLine();
-            while (!IsValidInput(playerInput, "MOVE"))
+            while (!IsValidInput(playerInput, "MOVE", moveMax))
             {
-                Console.WriteLine("Please enter a number between 1-9");
+                Console.WriteLine($"Please enter a number between 1-{moveMax}");
                 playerInput = Console.ReadLine();
             }
             return Int32.Parse(playerInput);
@@ -47,7 +48,7 @@ namespace TicTacToe
         public string GetMenuSelection()
         {
             string input = Console.ReadLine();
-            while (!IsValidInput(input, "MENU"))
+            while (!IsValidInput(input, "YES-OR-NO"))
             {
                 Console.WriteLine("Please enter 'Y' to play again or 'N' to quit");
                 input = Console.ReadLine();
@@ -79,8 +80,17 @@ namespace TicTacToe
             return Int32.Parse(input);
         }
 
-        public void PrintBoard(string[] board)
+        public int GetBoardSize()
         {
+            LogToConsole("Please select the board size: 3 for 3x3, 4 for 4x4, or 5 for 5x5");
+            string input = Console.ReadLine();
+            while (!IsValidInput(input, "BOARD-SIZE"))
+            {
+                Console.WriteLine("Please enter '3' for a 3x3 board, '4' for 4x4, or '5' for 5x5");
+                input = Console.ReadLine();
+            }
+            return Int32.Parse(input);
+        }
 
         public void PrintBoard(Board board)
         {
@@ -110,17 +120,19 @@ namespace TicTacToe
             this.LogToConsole(boardString);
         }
 
-        public bool IsValidInput(string input, string inputFor)
+        public bool IsValidInput(string input, string inputFor, int moveMax = 9)
         {
             int number;
             switch (inputFor)
             {
                 case "MOVE":
-                    return Int32.TryParse(input, out number) && number > 0 && number <= 9;
-                case "MENU":
+                    return Int32.TryParse(input, out number) && number > 0 && number <= moveMax;
+                case "YES-OR-NO":
                     return input.ToUpper() == "Y" || input.ToUpper() == "N" ? true : false;
                 case "ONE-OR-TWO":
                     return Int32.TryParse(input, out number) && number > 0 && number <= 2;
+                case "BOARD-SIZE":
+                    return Int32.TryParse(input, out number) && number >= 3 && number <= 5;
                 default:
                     return false;
             }
@@ -131,9 +143,10 @@ namespace TicTacToe
     public interface IUserInput
     {
         string[] GetPlayerNames(Game game);
-        int GetPlayerMove(Player player);
+        int GetPlayerMove(Player player, int boardSize);
         int GetNumberOfPlayers();
         int GetDifficultyLevel();
+        int GetBoardSize();
     }
 
     public interface IOutput

--- a/TicTacToe/CLI.cs
+++ b/TicTacToe/CLI.cs
@@ -79,7 +79,7 @@ namespace TicTacToe
             return Int32.Parse(input);
         }
 
-        public void PrintBoard(char[] board)
+        public void PrintBoard(string[] board)
         {
             string horizDivider = "  - - -+- - - -+- - -";
             this.LogToConsole("");
@@ -119,7 +119,7 @@ namespace TicTacToe
 
     public interface IOutput
     {
-        void PrintBoard(char[] board);
+        void PrintBoard(string[] board);
         void LogToConsole(string message);
     }
 }

--- a/TicTacToe/CLI.cs
+++ b/TicTacToe/CLI.cs
@@ -81,14 +81,33 @@ namespace TicTacToe
 
         public void PrintBoard(string[] board)
         {
-            string horizDivider = "  - - -+- - - -+- - -";
+
+        public void PrintBoard(Board board)
+        {
+            string horizDivider = "  - - -";
+            for (int i = 1; i < board.side; i++)
+            {
+                horizDivider += "+- - - -";
+            }
+            string boardString = "";
+            int index = 0;
             this.LogToConsole("");
-            this.LogToConsole($"   {board[0]}   |   {board[1]}   |   {board[2]} ");
-            this.LogToConsole(horizDivider);
-            this.LogToConsole($"   {board[3]}   |   {board[4]}   |   {board[5]} ");
-            this.LogToConsole(horizDivider);
-            this.LogToConsole($"   {board[6]}   |   {board[7]}   |   {board[8]} ");
-            this.LogToConsole("");
+            for (int row = 1; row <= board.side; row++)
+            {
+                string rowString = $"   {board.gameBoard[index]}   ";
+                index++;
+                for (int col = 2; col <= board.side; col++)
+                {
+                    rowString += $"|   {board.gameBoard[index]}   ";
+                    index++;
+                }
+                if (row == board.side)
+                {
+                    horizDivider = "";
+                }
+                boardString += $"{rowString}\n{horizDivider}\n";
+            }
+            this.LogToConsole(boardString);
         }
 
         public bool IsValidInput(string input, string inputFor)
@@ -119,7 +138,7 @@ namespace TicTacToe
 
     public interface IOutput
     {
-        void PrintBoard(string[] board);
+        void PrintBoard(Board board);
         void LogToConsole(string message);
     }
 }

--- a/TicTacToe/CLI.cs
+++ b/TicTacToe/CLI.cs
@@ -11,7 +11,7 @@ namespace TicTacToe
 
         public void WelcomeToGame()
         {
-            this.LogToConsole("Welcome to Tic Tac Toe!\n\n");
+            LogToConsole("Welcome to Tic Tac Toe!\n\n");
         }
 
         public string[] GetPlayerNames(Game game)
@@ -101,7 +101,7 @@ namespace TicTacToe
             }
             string boardString = "";
             int index = 0;
-            this.LogToConsole("");
+            LogToConsole("");
             for (int row = 1; row <= board.side; row++)
             {
                 string rowString = $"   {board.gameBoard[index]}   ";
@@ -117,7 +117,7 @@ namespace TicTacToe
                 }
                 boardString += $"{rowString}\n{horizDivider}\n";
             }
-            this.LogToConsole(boardString);
+            LogToConsole(boardString);
         }
 
         public bool IsValidInput(string input, string inputFor, int moveMax = 9)

--- a/TicTacToe/CLI.cs
+++ b/TicTacToe/CLI.cs
@@ -104,11 +104,13 @@ namespace TicTacToe
             LogToConsole("");
             for (int row = 1; row <= board.side; row++)
             {
-                string rowString = $"   {board.gameBoard[index]}   ";
+                string marker = board.gameBoard[index];
+                string rowString = $"  {(marker.Length > 1 ? "" : " ")}{marker}   ";
                 index++;
                 for (int col = 2; col <= board.side; col++)
                 {
-                    rowString += $"|   {board.gameBoard[index]}   ";
+                    marker = board.gameBoard[index];
+                    rowString += $"|  {(marker.Length > 1 ? "" : " ")}{marker}   ";
                     index++;
                 }
                 if (row == board.side)

--- a/TicTacToe/ComputerPlayer.cs
+++ b/TicTacToe/ComputerPlayer.cs
@@ -29,24 +29,24 @@ namespace TicTacToe
         public int FindBestMove(Game game)
         {
             int moveToBlock = 0;
-            for (int s = 1; s <= game.Board.Length; s++)
+            for (int s = 1; s <= game.Board.Length(); s++)
             {
-                if (game.SpaceIsAvailable(s))
+                if (game.Board.SpaceIsAvailable(s))
                 {
                     int index = s - 1;
-                    game.Board[index] = 'O';
+                    game.Board.gameBoard[index] = game.Player2Marker;
                     if (game.WinningCombinations().Contains(true))
                     {
-                        game.Board[index] = char.Parse(s.ToString());
+                        game.Board.gameBoard[index] = s.ToString();
                         return s;
                     }
-                    game.Board[index] = 'X';
+                    game.Board.gameBoard[index] = game.Player1Marker;
                     if (game.WinningCombinations().Contains(true))
                     {
-                        game.Board[index] = char.Parse(s.ToString());
+                        game.Board.gameBoard[index] = s.ToString();
                         moveToBlock = s;
                     }
-                    game.Board[index] = char.Parse(s.ToString());
+                    game.Board.gameBoard[index] = s.ToString();
                 }
             }
             return moveToBlock == 0 ? -1 : moveToBlock;
@@ -54,7 +54,7 @@ namespace TicTacToe
         public int PickRandomSpace(Game game)
         {
             int randomSpace = rand.Next(1, 10);
-            if (game.SpaceIsAvailable(randomSpace))
+            if (game.Board.SpaceIsAvailable(randomSpace))
             {
                 return randomSpace;
             }
@@ -84,7 +84,7 @@ namespace TicTacToe
         public int PickRandomSpace(Game game)
         {
             int randomSpace = rand.Next(1, 10);
-            if (game.SpaceIsAvailable(randomSpace))
+            if (game.Board.SpaceIsAvailable(randomSpace))
             {
                 return randomSpace;
             }

--- a/TicTacToe/ComputerPlayer.cs
+++ b/TicTacToe/ComputerPlayer.cs
@@ -35,13 +35,13 @@ namespace TicTacToe
                 {
                     int index = s - 1;
                     game.Board.gameBoard[index] = game.Player2Marker;
-                    if (game.WinningCombinations().Contains(true))
+                    if (game.Board.HasWinningCombination())
                     {
                         game.Board.gameBoard[index] = s.ToString();
                         return s;
                     }
                     game.Board.gameBoard[index] = game.Player1Marker;
-                    if (game.WinningCombinations().Contains(true))
+                    if (game.Board.HasWinningCombination())
                     {
                         game.Board.gameBoard[index] = s.ToString();
                         moveToBlock = s;

--- a/TicTacToe/ComputerPlayer.cs
+++ b/TicTacToe/ComputerPlayer.cs
@@ -16,15 +16,13 @@ namespace TicTacToe
             this.Marker = 'O';
         }
 
-        public Random rand = new Random();
-
         public string Name { get; }
         public char Marker { get; }
 
         public int MakeMove(Game game)
         {
             int nextMove = FindBestMove(game);
-            return nextMove != -1 ? nextMove : PickRandomSpace(game);
+            return nextMove != -1 ? nextMove : game.Board.GetRandomSpace();
         }
         public int FindBestMove(Game game)
         {
@@ -51,19 +49,8 @@ namespace TicTacToe
             }
             return moveToBlock == 0 ? -1 : moveToBlock;
         }
-        public int PickRandomSpace(Game game)
-        {
-            int randomSpace = rand.Next(1, 10);
-            if (game.Board.SpaceIsAvailable(randomSpace))
-            {
-                return randomSpace;
-            }
-            else
-            {
-                return PickRandomSpace(game);
-            }
-        }
     }
+
     public class EasyComputerPlayer : IComputerPlayer
     {
         public EasyComputerPlayer()
@@ -79,19 +66,7 @@ namespace TicTacToe
 
         public int MakeMove(Game game)
         {
-            return PickRandomSpace(game);
-        }
-        public int PickRandomSpace(Game game)
-        {
-            int randomSpace = rand.Next(1, 10);
-            if (game.Board.SpaceIsAvailable(randomSpace))
-            {
-                return randomSpace;
-            }
-            else
-            {
-                return PickRandomSpace(game);
-            }
+            return game.Board.GetRandomSpace();
         }
     }
 }

--- a/TicTacToe/Game.cs
+++ b/TicTacToe/Game.cs
@@ -5,6 +5,8 @@ namespace TicTacToe
 {
     public class Game
     {
+        static BoardFactory boardFactory = new BoardFactory();
+
         public string Player1Marker = "X";
         public string Player2Marker = "O";
         public Game()
@@ -46,14 +48,20 @@ namespace TicTacToe
             this.CurrentPlayer = this.Player1;
         }
 
+        public void SetBoardSize(IUserInput input)
+        {
+            int boardSize = input.GetBoardSize();
+            this.Board = boardFactory.BuildBoard(boardSize);
+        }
+
         public void DisplayCurrentBoard(IOutput output)
         {
-            output.PrintBoard(Board.gameBoard);
+            output.PrintBoard(Board);
         }
 
         public int NextPlayerMove(IUserInput input)
         {
-            int move = input.GetPlayerMove(this.CurrentPlayer);
+            int move = input.GetPlayerMove(this.CurrentPlayer, Board.side);
             return move;
         }
 

--- a/TicTacToe/Game.cs
+++ b/TicTacToe/Game.cs
@@ -23,8 +23,7 @@ namespace TicTacToe
 
         public void MakeMove(int space)
         {
-            int index = space - 1;
-            this.Board[index] = this.CurrentPlayer.Marker;
+            Board.UpdateSpace(space, CurrentPlayer.Marker);
         }
 
         public void AddPlayers(IUserInput input)
@@ -59,23 +58,23 @@ namespace TicTacToe
             return move;
         }
 
-        public bool SpaceIsAvailable(int space)
-        {
-            int index = space - 1;
-            return Board[index] != Player1Marker && Board[index] != Player2Marker;
-        }
+        // public bool SpaceIsAvailable(int space)
+        // {
+        //     int index = space - 1;
+        //     return Board.gameBoard[index] != Player1Marker && Board.gameBoard[index] != Player2Marker;
+        // }
 
-        public bool BoardIsFull()
-        {
-            for ( int i = 1; i < this.Board.Length + 1; i++ )
-            {
-                if (SpaceIsAvailable(i))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
+        // public bool BoardIsFull()
+        // {
+        //     for ( int i = 1; i < this.Board.gameBoard.Length + 1; i++ )
+        //     {
+        //         if (SpaceIsAvailable(i))
+        //         {
+        //             return false;
+        //         }
+        //     }
+        //     return true;
+        // }
 
         public void SwitchCurrentPlayer()
         {
@@ -85,14 +84,14 @@ namespace TicTacToe
         public bool[] WinningCombinations()
         {
             return new bool[] {
-                Board[0] == Board[1] && Board[1] == Board[2],
-                Board[3] == Board[4] && Board[4] == Board[5],
-                Board[6] == Board[7] && Board[7] == Board[8],
-                Board[0] == Board[3] && Board[3] == Board[6],
-                Board[1] == Board[4] && Board[4] == Board[7],
-                Board[2] == Board[5] && Board[5] == Board[8],
-                Board[0] == Board[4] && Board[4] == Board[8],
-                Board[2] == Board[4] && Board[4] == Board[6],
+                Board.gameBoard[0] == Board.gameBoard[1] && Board.gameBoard[1] == Board.gameBoard[2],
+                Board.gameBoard[3] == Board.gameBoard[4] && Board.gameBoard[4] == Board.gameBoard[5],
+                Board.gameBoard[6] == Board.gameBoard[7] && Board.gameBoard[7] == Board.gameBoard[8],
+                Board.gameBoard[0] == Board.gameBoard[3] && Board.gameBoard[3] == Board.gameBoard[6],
+                Board.gameBoard[1] == Board.gameBoard[4] && Board.gameBoard[4] == Board.gameBoard[7],
+                Board.gameBoard[2] == Board.gameBoard[5] && Board.gameBoard[5] == Board.gameBoard[8],
+                Board.gameBoard[0] == Board.gameBoard[4] && Board.gameBoard[4] == Board.gameBoard[8],
+                Board.gameBoard[2] == Board.gameBoard[4] && Board.gameBoard[4] == Board.gameBoard[6],
             };
         }
 
@@ -108,7 +107,7 @@ namespace TicTacToe
                 this.State = "WIN";
                 return true;
             }
-            else if (BoardIsFull())
+            else if (Board.IsFull())
             {
                 this.State = "DRAW";
                 return true;

--- a/TicTacToe/Game.cs
+++ b/TicTacToe/Game.cs
@@ -29,29 +29,29 @@ namespace TicTacToe
 
         public void AddPlayers(IUserInput input)
         {
-            this.NumberOfPlayers = input.GetNumberOfPlayers();
+            NumberOfPlayers = input.GetNumberOfPlayers();
             string[] names = input.GetPlayerNames(this);
-            this.Player1 = new Player(names[0], Player1Marker);
-            this.Player2 = new Player(names[1], Player2Marker);
-            if (this.NumberOfPlayers == 1)
+            Player1 = new Player(names[0], Player1Marker);
+            Player2 = new Player(names[1], Player2Marker);
+            if (NumberOfPlayers == 1)
             {
                 int selectedDifficulty = input.GetDifficultyLevel();
                 if (selectedDifficulty == 1)
                 {
-                    this.ComputerPlayer = new EasyComputerPlayer();
+                    ComputerPlayer = new EasyComputerPlayer();
                 }
                 else
                 {
-                    this.ComputerPlayer = new HardComputerPlayer();
+                    ComputerPlayer = new HardComputerPlayer();
                 }
             }
-            this.CurrentPlayer = this.Player1;
+            CurrentPlayer = Player1;
         }
 
         public void SetBoardSize(IUserInput input)
         {
             int boardSize = input.GetBoardSize();
-            this.Board = boardFactory.BuildBoard(boardSize);
+            Board = boardFactory.BuildBoard(boardSize);
         }
 
         public void DisplayCurrentBoard(IOutput output)
@@ -61,7 +61,7 @@ namespace TicTacToe
 
         public int NextPlayerMove(IUserInput input)
         {
-            int move = input.GetPlayerMove(this.CurrentPlayer, Board.side);
+            int move = input.GetPlayerMove(CurrentPlayer, Board.side);
             return move;
         }
 
@@ -76,15 +76,15 @@ namespace TicTacToe
             {
                 if (NumberOfPlayers == 1 && CurrentPlayer == Player2)
                 {
-                    this.State = "LOSE";
+                    State = "LOSE";
                     return true;
                 }
-                this.State = "WIN";
+                State = "WIN";
                 return true;
             }
             else if (Board.IsFull())
             {
-                this.State = "DRAW";
+                State = "DRAW";
                 return true;
             }
             return false;
@@ -93,7 +93,7 @@ namespace TicTacToe
         public string DisplayResult()
         {
             string result = "";
-            switch (this.State)
+            switch (State)
             {
                 case "WIN":
                     result = $"Congratulations {this.CurrentPlayer.Name}, you won!";

--- a/TicTacToe/Game.cs
+++ b/TicTacToe/Game.cs
@@ -5,15 +5,15 @@ namespace TicTacToe
 {
     public class Game
     {
-        public char Player1Marker = 'X';
-        public char Player2Marker = 'O';
+        public string Player1Marker = "X";
+        public string Player2Marker = "O";
         public Game()
         {
-            this.Board = new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+            // this.Board = new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
             this.State = "";
         }
 
-        public char[] Board { get; set; }
+        public Board Board { get; set; }
         public int NumberOfPlayers { get; set; }
         public Player Player1 { get; set; }
         public Player Player2 { get; set; }
@@ -49,7 +49,7 @@ namespace TicTacToe
 
         public void DisplayCurrentBoard(IOutput output)
         {
-            output.PrintBoard(this.Board);
+            output.PrintBoard(Board.gameBoard);
         }
 
         public int NextPlayerMove(IUserInput input)

--- a/TicTacToe/Game.cs
+++ b/TicTacToe/Game.cs
@@ -9,7 +9,6 @@ namespace TicTacToe
         public string Player2Marker = "O";
         public Game()
         {
-            // this.Board = new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
             this.State = "";
         }
 
@@ -58,46 +57,14 @@ namespace TicTacToe
             return move;
         }
 
-        // public bool SpaceIsAvailable(int space)
-        // {
-        //     int index = space - 1;
-        //     return Board.gameBoard[index] != Player1Marker && Board.gameBoard[index] != Player2Marker;
-        // }
-
-        // public bool BoardIsFull()
-        // {
-        //     for ( int i = 1; i < this.Board.gameBoard.Length + 1; i++ )
-        //     {
-        //         if (SpaceIsAvailable(i))
-        //         {
-        //             return false;
-        //         }
-        //     }
-        //     return true;
-        // }
-
         public void SwitchCurrentPlayer()
         {
             CurrentPlayer = CurrentPlayer == Player1 ? Player2 : Player1;
         }
 
-        public bool[] WinningCombinations()
-        {
-            return new bool[] {
-                Board.gameBoard[0] == Board.gameBoard[1] && Board.gameBoard[1] == Board.gameBoard[2],
-                Board.gameBoard[3] == Board.gameBoard[4] && Board.gameBoard[4] == Board.gameBoard[5],
-                Board.gameBoard[6] == Board.gameBoard[7] && Board.gameBoard[7] == Board.gameBoard[8],
-                Board.gameBoard[0] == Board.gameBoard[3] && Board.gameBoard[3] == Board.gameBoard[6],
-                Board.gameBoard[1] == Board.gameBoard[4] && Board.gameBoard[4] == Board.gameBoard[7],
-                Board.gameBoard[2] == Board.gameBoard[5] && Board.gameBoard[5] == Board.gameBoard[8],
-                Board.gameBoard[0] == Board.gameBoard[4] && Board.gameBoard[4] == Board.gameBoard[8],
-                Board.gameBoard[2] == Board.gameBoard[4] && Board.gameBoard[4] == Board.gameBoard[6],
-            };
-        }
-
         public bool IsOver()
         {
-            if (WinningCombinations().Contains(true))
+            if (Board.HasWinningCombination())
             {
                 if (NumberOfPlayers == 1 && CurrentPlayer == Player2)
                 {

--- a/TicTacToe/Player.cs
+++ b/TicTacToe/Player.cs
@@ -4,13 +4,13 @@ namespace TicTacToe
 {
     public class Player
     {
-        public Player(string name, char marker)
+        public Player(string name, string marker)
         {
             this.Name = name;
             this.Marker = marker;
         }
 
         public string Name { get; set; }
-        public char Marker { get; set; }
+        public string Marker { get; set; }
     }
 }

--- a/TicTacToe/Program.cs
+++ b/TicTacToe/Program.cs
@@ -5,6 +5,7 @@ namespace TicTacToe
     class Program
     {
         static CLI cli = new CLI();
+        static BoardFactory boardFactory = new BoardFactory();
         public static string play = "Y";
 
         static void Main(string[] args)
@@ -20,6 +21,7 @@ namespace TicTacToe
         static Game StartNewGame()
         {
             Game game = new Game();
+            game.Board = boardFactory.BuildBoard(3);
             cli.WelcomeToGame();
             game.AddPlayers(cli);
             return game;
@@ -29,7 +31,7 @@ namespace TicTacToe
         {
             game.DisplayCurrentBoard(cli);
             int nextMove = game.NextPlayerMove(cli);
-            while (!game.SpaceIsAvailable(nextMove))
+            while (!game.Board.SpaceIsAvailable(nextMove))
             {
                 cli.LogToConsole("Sorry, that space isn't available");
                 nextMove = game.NextPlayerMove(cli);

--- a/TicTacToe/Program.cs
+++ b/TicTacToe/Program.cs
@@ -5,7 +5,6 @@ namespace TicTacToe
     class Program
     {
         static CLI cli = new CLI();
-        static BoardFactory boardFactory = new BoardFactory();
         public static string play = "Y";
 
         static void Main(string[] args)
@@ -21,9 +20,9 @@ namespace TicTacToe
         static Game StartNewGame()
         {
             Game game = new Game();
-            game.Board = boardFactory.BuildBoard(3);
             cli.WelcomeToGame();
             game.AddPlayers(cli);
+            game.SetBoardSize(cli);
             return game;
         }
 


### PR DESCRIPTION
Adds the option for the player(s) to select a board size – limited now to 3x3, 4x4, or 5x5 (although larger sizes could be handled as well). Refactored to introduce a new Board class as well as a BoardFactory to programmatically generate and populate new boards of a given size. Some of the board-related logic has been moved to the Board class, including determining space availability, picking a random open space, and evaluating possible winning combinations.

Includes tests for Board and BoardFactory, as well as some existing tests moved where relevant.